### PR TITLE
chore: Update coverage report dates and improve CSS styling

### DIFF
--- a/contract/coverage-report/gcov.css
+++ b/contract/coverage-report/gcov.css
@@ -1,519 +1,246 @@
-/* All views: initial background and text color */
-body
-{
-  color: #000000;
-  background-color: #ffffff;
+/* Modern Reset */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
-/* All views: standard link format*/
-a:link
-{
-  color: #284fa8;
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 1.6;
+  color: #333;
+  background-color: #f8f9fa;
+  padding: 2rem;
+}
+
+/* Main Container Styling */
+table {
+  border-collapse: collapse;
+  width: 100%;
+  background-color: white;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+}
+
+/* Title Section */
+.title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  padding: 1.5rem;
+  background: linear-gradient(135deg, #4b6cb7, #182848);
+  color: white;
+}
+
+/* Ruler styling */
+.ruler {
+  height: 3px;
+  background: linear-gradient(to right, #4b6cb7, #182848);
+  padding: 0;
+}
+
+.ruler img {
+  display: none; /* Hide the glass.png and use CSS instead */
+}
+
+/* Header Section */
+.headerItem {
+  font-weight: 600;
+  color: #555;
+  padding: 0.75rem;
+  text-align: right;
+}
+
+.headerValue {
+  padding: 0.75rem;
+  color: #333;
+}
+
+.headerCovTableHead {
+  font-weight: 600;
+  padding: 0.75rem;
+  text-align: center;
+  background-color: #f1f3f5;
+}
+
+.headerCovTableEntry {
+  text-align: center;
+  padding: 0.75rem;
+}
+
+.headerCovTableEntryLo {
+  text-align: center;
+  padding: 0.75rem;
+  color: #e03131;
+  font-weight: 600;
+}
+
+.headerCovTableEntryMed {
+  text-align: center;
+  padding: 0.75rem;
+  color: #f59f00;
+  font-weight: 600;
+}
+
+.headerCovTableEntryHi {
+  text-align: center;
+  padding: 0.75rem;
+  color: #2f9e44;
+  font-weight: 600;
+}
+
+/* Directory Table */
+center {
+  margin: 2rem 0;
+}
+
+center table {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.tableHead {
+  background-color: #f1f3f5;
+  padding: 1rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.tableHead a {
+  color: #4263eb;
+  text-decoration: none;
+}
+
+.tableHead a:hover {
   text-decoration: underline;
 }
 
-/* All views: standard link - visited format */
-a:visited
-{
-  color: #00cb40;
+.tableHeadSort img {
+  vertical-align: middle;
+  margin-left: 0.25rem;
+}
+
+.coverFile {
+  padding: 1rem;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.coverFile a {
+  color: #4263eb;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.coverFile a:hover {
   text-decoration: underline;
 }
 
-/* All views: standard link - activated format */
-a:active
-{
-  color: #ff0040;
+/* Coverage Bars */
+.coverBar {
+  padding: 1rem;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.coverBarOutline {
+  display: inline-block;
+  width: 100px;
+  height: 10px;
+  background-color: #e9ecef;
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+/* Replace the image-based coverage bars with CSS */
+.coverBarOutline img[src="snow.png"] {
+  display: block;
+  height: 10px;
+  background-color: #e9ecef;
+}
+
+.coverBarOutline img[src="ruby.png"] {
+  display: block;
+  height: 10px;
+  background-color: #fa5252;
+}
+
+.coverBarOutline img[src="amber.png"] {
+  display: block;
+  height: 10px;
+  background-color: #fd7e14;
+}
+
+.coverBarOutline img[src="emerald.png"] {
+  display: block;
+  height: 10px;
+  background-color: #40c057;
+}
+
+/* Coverage Percentage Cells */
+.coverPerLo, .coverNumLo {
+  padding: 1rem;
+  text-align: center;
+  color: #e03131;
+  font-weight: 500;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.coverPerMed, .coverNumMed {
+  padding: 1rem;
+  text-align: center;
+  color: #f59f00;
+  font-weight: 500;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.coverPerHi, .coverNumHi {
+  padding: 1rem;
+  text-align: center;
+  color: #2f9e44;
+  font-weight: 500;
+  border-bottom: 1px solid #e9ecef;
+}
+
+/* Footer */
+.versionInfo {
+  text-align: center;
+  color: #868e96;
+  padding: 1rem;
+  font-size: 0.875rem;
+}
+
+.versionInfo a {
+  color: #4263eb;
+  text-decoration: none;
+}
+
+.versionInfo a:hover {
   text-decoration: underline;
 }
 
-/* All views: main title format */
-td.title
-{
-  text-align: center;
-  padding-bottom: 10px;
-  font-family: sans-serif;
-  font-size: 20pt;
-  font-style: italic;
-  font-weight: bold;
-}
-
-/* All views: header item format */
-td.headerItem
-{
-  text-align: right;
-  padding-right: 6px;
-  font-family: sans-serif;
-  font-weight: bold;
-  vertical-align: top;
-  white-space: nowrap;
-}
-
-/* All views: header item value format */
-td.headerValue
-{
-  text-align: left;
-  color: #284fa8;
-  font-family: sans-serif;
-  font-weight: bold;
-  white-space: nowrap;
-}
-
-/* All views: header item coverage table heading */
-td.headerCovTableHead
-{
-  text-align: center;
-  padding-right: 6px;
-  padding-left: 6px;
-  padding-bottom: 0px;
-  font-family: sans-serif;
-  font-size: 80%;
-  white-space: nowrap;
-}
-
-/* All views: header item coverage table entry */
-td.headerCovTableEntry
-{
-  text-align: right;
-  color: #284fa8;
-  font-family: sans-serif;
-  font-weight: bold;
-  white-space: nowrap;
-  padding-left: 12px;
-  padding-right: 4px;
-  background-color: #dae7fe;
-}
-
-/* All views: header item coverage table entry for high coverage rate */
-td.headerCovTableEntryHi
-{
-  text-align: right;
-  color: #000000;
-  font-family: sans-serif;
-  font-weight: bold;
-  white-space: nowrap;
-  padding-left: 12px;
-  padding-right: 4px;
-  background-color: #a7fc9d;
-}
-
-/* All views: header item coverage table entry for medium coverage rate */
-td.headerCovTableEntryMed
-{
-  text-align: right;
-  color: #000000;
-  font-family: sans-serif;
-  font-weight: bold;
-  white-space: nowrap;
-  padding-left: 12px;
-  padding-right: 4px;
-  background-color: #ffea20;
-}
-
-/* All views: header item coverage table entry for ow coverage rate */
-td.headerCovTableEntryLo
-{
-  text-align: right;
-  color: #000000;
-  font-family: sans-serif;
-  font-weight: bold;
-  white-space: nowrap;
-  padding-left: 12px;
-  padding-right: 4px;
-  background-color: #ff0000;
-}
-
-/* All views: header legend value for legend entry */
-td.headerValueLeg
-{
-  text-align: left;
-  color: #000000;
-  font-family: sans-serif;
-  font-size: 80%;
-  white-space: nowrap;
-  padding-top: 4px;
-}
-
-/* All views: color of horizontal ruler */
-td.ruler
-{
-  background-color: #6688d4;
-}
-
-/* All views: version string format */
-td.versionInfo
-{
-  text-align: center;
-  padding-top: 2px;
-  font-family: sans-serif;
-  font-style: italic;
-}
-
-/* Directory view/File view (all)/Test case descriptions:
-   table headline format */
-td.tableHead
-{
-  text-align: center;
-  color: #ffffff;
-  background-color: #6688d4;
-  font-family: sans-serif;
-  font-size: 120%;
-  font-weight: bold;
-  white-space: nowrap;
-  padding-left: 4px;
-  padding-right: 4px;
-}
-
-span.tableHeadSort
-{
-  padding-right: 4px;
-}
-
-/* Directory view/File view (all): filename entry format */
-td.coverFile
-{
-  text-align: left;
-  padding-left: 10px;
-  padding-right: 20px; 
-  color: #284fa8;
-  background-color: #dae7fe;
-  font-family: monospace;
-}
-
-/* Directory view/File view (all): bar-graph entry format*/
-td.coverBar
-{
-  padding-left: 10px;
-  padding-right: 10px;
-  background-color: #dae7fe;
-}
-
-/* Directory view/File view (all): bar-graph outline color */
-td.coverBarOutline
-{
-  background-color: #000000;
-}
-
-/* Directory view/File view (all): percentage entry for files with
-   high coverage rate */
-td.coverPerHi
-{
-  text-align: right;
-  padding-left: 10px;
-  padding-right: 10px;
-  background-color: #a7fc9d;
-  font-weight: bold;
-  font-family: sans-serif;
-}
-
-/* Directory view/File view (all): line count entry for files with
-   high coverage rate */
-td.coverNumHi
-{
-  text-align: right;
-  padding-left: 10px;
-  padding-right: 10px;
-  background-color: #a7fc9d;
-  white-space: nowrap;
-  font-family: sans-serif;
-}
-
-/* Directory view/File view (all): percentage entry for files with
-   medium coverage rate */
-td.coverPerMed
-{
-  text-align: right;
-  padding-left: 10px;
-  padding-right: 10px;
-  background-color: #ffea20;
-  font-weight: bold;
-  font-family: sans-serif;
-}
-
-/* Directory view/File view (all): line count entry for files with
-   medium coverage rate */
-td.coverNumMed
-{
-  text-align: right;
-  padding-left: 10px;
-  padding-right: 10px;
-  background-color: #ffea20;
-  white-space: nowrap;
-  font-family: sans-serif;
-}
-
-/* Directory view/File view (all): percentage entry for files with
-   low coverage rate */
-td.coverPerLo
-{
-  text-align: right;
-  padding-left: 10px;
-  padding-right: 10px;
-  background-color: #ff0000;
-  font-weight: bold;
-  font-family: sans-serif;
-}
-
-/* Directory view/File view (all): line count entry for files with
-   low coverage rate */
-td.coverNumLo
-{
-  text-align: right;
-  padding-left: 10px;
-  padding-right: 10px;
-  background-color: #ff0000;
-  white-space: nowrap;
-  font-family: sans-serif;
-}
-
-/* File view (all): "show/hide details" link format */
-a.detail:link
-{
-  color: #B8D0FF;
-  font-size:80%;
-}
-
-/* File view (all): "show/hide details" link - visited format */
-a.detail:visited
-{
-  color: #B8D0FF;
-  font-size:80%;
-}
-
-/* File view (all): "show/hide details" link - activated format */
-a.detail:active
-{
-  color: #ffffff;
-  font-size:80%;
-}
-
-/* File view (detail): test name entry */
-td.testName
-{
-  text-align: right;
-  padding-right: 10px;
-  background-color: #dae7fe;
-  font-family: sans-serif;
-}
-
-/* File view (detail): test percentage entry */
-td.testPer
-{
-  text-align: right;
-  padding-left: 10px;
-  padding-right: 10px; 
-  background-color: #dae7fe;
-  font-family: sans-serif;
-}
-
-/* File view (detail): test lines count entry */
-td.testNum
-{
-  text-align: right;
-  padding-left: 10px;
-  padding-right: 10px; 
-  background-color: #dae7fe;
-  font-family: sans-serif;
-}
-
-/* Test case descriptions: test name format*/
-dt
-{
-  font-family: sans-serif;
-  font-weight: bold;
-}
-
-/* Test case descriptions: description table body */
-td.testDescription
-{
-  padding-top: 10px;
-  padding-left: 30px;
-  padding-bottom: 10px;
-  padding-right: 30px;
-  background-color: #dae7fe;
-}
-
-/* Source code view: function entry */
-td.coverFn
-{
-  text-align: left;
-  padding-left: 10px;
-  padding-right: 20px; 
-  color: #284fa8;
-  background-color: #dae7fe;
-  font-family: monospace;
-}
-
-/* Source code view: function entry zero count*/
-td.coverFnLo
-{
-  text-align: right;
-  padding-left: 10px;
-  padding-right: 10px;
-  background-color: #ff0000;
-  font-weight: bold;
-  font-family: sans-serif;
-}
-
-/* Source code view: function entry nonzero count*/
-td.coverFnHi
-{
-  text-align: right;
-  padding-left: 10px;
-  padding-right: 10px;
-  background-color: #dae7fe;
-  font-weight: bold;
-  font-family: sans-serif;
-}
-
-/* Source code view: source code format */
-pre.source
-{
-  font-family: monospace;
-  white-space: pre;
-  margin-top: 2px;
-}
-
-/* Source code view: line number format */
-span.lineNum
-{
-  background-color: #efe383;
-}
-
-/* Source code view: format for lines which were executed */
-td.lineCov,
-span.lineCov
-{
-  background-color: #cad7fe;
-}
-
-/* Source code view: format for Cov legend */
-span.coverLegendCov
-{
-  padding-left: 10px;
-  padding-right: 10px;
-  padding-bottom: 2px;
-  background-color: #cad7fe;
-}
-
-/* Source code view: format for lines which were not executed */
-td.lineNoCov,
-span.lineNoCov
-{
-  background-color: #ff6230;
-}
-
-/* Source code view: format for NoCov legend */
-span.coverLegendNoCov
-{
-  padding-left: 10px;
-  padding-right: 10px;
-  padding-bottom: 2px;
-  background-color: #ff6230;
-}
-
-/* Source code view (function table): standard link - visited format */
-td.lineNoCov > a:visited,
-td.lineCov > a:visited
-{  
-  color: #000000;
-  text-decoration: underline;
-}  
-
-/* Source code view: format for lines which were executed only in a
-   previous version */
-span.lineDiffCov
-{
-  background-color: #b5f7af;
-}
-
-/* Source code view: format for branches which were executed
- * and taken */
-span.branchCov
-{
-  background-color: #cad7fe;
-}
-
-/* Source code view: format for branches which were executed
- * but not taken */
-span.branchNoCov
-{
-  background-color: #ff6230;
-}
-
-/* Source code view: format for branches which were not executed */
-span.branchNoExec
-{
-  background-color: #ff6230;
-}
-
-/* Source code view: format for the source code heading line */
-pre.sourceHeading
-{
-  white-space: pre;
-  font-family: monospace;
-  font-weight: bold;
-  margin: 0px;
-}
-
-/* All views: header legend value for low rate */
-td.headerValueLegL
-{
-  font-family: sans-serif;
-  text-align: center;
-  white-space: nowrap;
-  padding-left: 4px;
-  padding-right: 2px;
-  background-color: #ff0000;
-  font-size: 80%;
-}
-
-/* All views: header legend value for med rate */
-td.headerValueLegM
-{
-  font-family: sans-serif;
-  text-align: center;
-  white-space: nowrap;
-  padding-left: 2px;
-  padding-right: 2px;
-  background-color: #ffea20;
-  font-size: 80%;
-}
-
-/* All views: header legend value for hi rate */
-td.headerValueLegH
-{
-  font-family: sans-serif;
-  text-align: center;
-  white-space: nowrap;
-  padding-left: 2px;
-  padding-right: 4px;
-  background-color: #a7fc9d;
-  font-size: 80%;
-}
-
-/* All views except source code view: legend format for low coverage */
-span.coverLegendCovLo
-{
-  padding-left: 10px;
-  padding-right: 10px;
-  padding-top: 2px;
-  background-color: #ff0000;
-}
-
-/* All views except source code view: legend format for med coverage */
-span.coverLegendCovMed
-{
-  padding-left: 10px;
-  padding-right: 10px;
-  padding-top: 2px;
-  background-color: #ffea20;
-}
-
-/* All views except source code view: legend format for hi coverage */
-span.coverLegendCovHi
-{
-  padding-left: 10px;
-  padding-right: 10px;
-  padding-top: 2px;
-  background-color: #a7fc9d;
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  body {
+    padding: 1rem;
+  }
+  
+  .title {
+    font-size: 1.25rem;
+    padding: 1rem;
+  }
+  
+  center table {
+    width: 100%;
+  }
+  
+  .headerItem, .headerValue, .headerCovTableHead, 
+  .headerCovTableEntry, .tableHead, .coverFile, 
+  .coverBar, .coverPerLo, .coverNumLo, 
+  .coverPerMed, .coverNumMed, .coverPerHi, .coverNumHi {
+    padding: 0.5rem;
+    font-size: 0.875rem;
+  }
+  
+  .coverBarOutline {
+    width: 60px;
+  }
 }

--- a/contract/coverage-report/index-sort-f.html
+++ b/contract/coverage-report/index-sort-f.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">8</td>

--- a/contract/coverage-report/index-sort-l.html
+++ b/contract/coverage-report/index-sort-l.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">8</td>

--- a/contract/coverage-report/index.html
+++ b/contract/coverage-report/index.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:22:39</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">8</td>

--- a/contract/coverage-report/script/GetGift.s.sol.func-sort-c.html
+++ b/contract/coverage-report/script/GetGift.s.sol.func-sort-c.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">0</td>

--- a/contract/coverage-report/script/GetGift.s.sol.func.html
+++ b/contract/coverage-report/script/GetGift.s.sol.func.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">0</td>

--- a/contract/coverage-report/script/GetGift.s.sol.gcov.html
+++ b/contract/coverage-report/script/GetGift.s.sol.gcov.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">0</td>

--- a/contract/coverage-report/script/index-sort-f.html
+++ b/contract/coverage-report/script/index-sort-f.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">0</td>

--- a/contract/coverage-report/script/index-sort-l.html
+++ b/contract/coverage-report/script/index-sort-l.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">0</td>

--- a/contract/coverage-report/script/index.html
+++ b/contract/coverage-report/script/index.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">0</td>

--- a/contract/coverage-report/src/GetGift.sol.func-sort-c.html
+++ b/contract/coverage-report/src/GetGift.sol.func-sort-c.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">6</td>

--- a/contract/coverage-report/src/GetGift.sol.func.html
+++ b/contract/coverage-report/src/GetGift.sol.func.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">6</td>

--- a/contract/coverage-report/src/GetGift.sol.gcov.html
+++ b/contract/coverage-report/src/GetGift.sol.gcov.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">6</td>

--- a/contract/coverage-report/src/index-sort-f.html
+++ b/contract/coverage-report/src/index-sort-f.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">6</td>

--- a/contract/coverage-report/src/index-sort-l.html
+++ b/contract/coverage-report/src/index-sort-l.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">6</td>

--- a/contract/coverage-report/src/index.html
+++ b/contract/coverage-report/src/index.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">6</td>

--- a/contract/coverage-report/test/utilites/GetGift.utils.t.sol.func-sort-c.html
+++ b/contract/coverage-report/test/utilites/GetGift.utils.t.sol.func-sort-c.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">2</td>

--- a/contract/coverage-report/test/utilites/GetGift.utils.t.sol.func.html
+++ b/contract/coverage-report/test/utilites/GetGift.utils.t.sol.func.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">2</td>

--- a/contract/coverage-report/test/utilites/GetGift.utils.t.sol.gcov.html
+++ b/contract/coverage-report/test/utilites/GetGift.utils.t.sol.gcov.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">2</td>

--- a/contract/coverage-report/test/utilites/index-sort-f.html
+++ b/contract/coverage-report/test/utilites/index-sort-f.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">2</td>

--- a/contract/coverage-report/test/utilites/index-sort-l.html
+++ b/contract/coverage-report/test/utilites/index-sort-l.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">2</td>

--- a/contract/coverage-report/test/utilites/index.html
+++ b/contract/coverage-report/test/utilites/index.html
@@ -37,7 +37,7 @@
           </tr>
           <tr>
             <td class="headerItem">Date:</td>
-            <td class="headerValue">2025-05-17 21:09:32</td>
+            <td class="headerValue">2025-05-19 19:37:42</td>
             <td></td>
             <td class="headerItem">Functions:</td>
             <td class="headerCovTableEntry">2</td>


### PR DESCRIPTION
- Updated date entries in multiple coverage report HTML files to reflect the latest timestamp.
- Refactored gcov.css to modernize styles, reduce redundancy, and enhance responsiveness across devices.
- Replaced image-based coverage bars with CSS for improved performance and maintainability.